### PR TITLE
Update deprecated .hover() method to use .on()

### DIFF
--- a/src/deprecated/event.js
+++ b/src/deprecated/event.js
@@ -4,7 +4,6 @@ import "../event.js";
 import "../event/trigger.js";
 
 jQuery.fn.extend( {
-
 	bind: function( types, data, fn ) {
 		return this.on( types, null, data, fn );
 	},
@@ -24,7 +23,7 @@ jQuery.fn.extend( {
 	},
 
 	hover: function( fnOver, fnOut ) {
-		return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
+		return this.on( "mouseenter", fnOver ).on( "mouseleave", fnOut || fnOver );
 	}
 } );
 


### PR DESCRIPTION
Summary: The deprecated .hover() method in src/deprecated/event.js has been updated to use .on() instead of .mouseenter() and .mouseleave().

Reasoning: This change ensures that the .hover() method does not rely on other deprecated methods, improving compatibility and reducing potential issues.

Impacts: Reviewers should ensure that the updated .hover() method works as expected and does not introduce any new bugs. Additionally, any code that relies on the .hover() method should be updated to use the new implementation.

Issue Resolution: This pull request addresses the issue of removing deprecated methods by updating the .hover() method to use .on() instead of .mouseenter() and .mouseleave().

This PR fixes #1